### PR TITLE
Change TrailingComma from 'all' to 'es5'

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
             'error',
             {
                 singleQuote: true,
-                trailingComma: 'all',
+                trailingComma: 'es5',
                 bracketSpacing: false,
                 jsxBracketSameLine: true,
                 parser: 'flow',


### PR DESCRIPTION
Trailing commas in function invocation are not supported. 
https://github.com/prettier/prettier/issues/266
https://github.com/prettier/prettier/pull/641