### PR TITLE
Fix for unmet dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "eslint-config-prettier": "^2.3.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-jsx-a11y": "^6.0.0",
     "eslint-plugin-prettier": "^2.2.0",
-    "eslint-plugin-react": "^7.1.0",
+    "eslint-plugin-react": "^8.2.0",
     "prettier": "^1.5.3"
   }
 }


### PR DESCRIPTION
Ref: #2 

Updated version support for `babel-eslint` (no breaking changes) and `eslint-plugin-jsx-a11y` (no breaking changes here too).