### PR TITLE
New eslint based on eslint-create-react-app

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,9 +28,9 @@ $ npm install --save-dev @improntaadvance/eslint-config
 Then install all the `peer-dependencies` of the module:
 
 ```sh
-$ yarn add --dev eslint prettier eslint-config-prettier eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-flowtype eslint-plugin-prettier eslint-plugin-react babel-eslint
+$ yarn add --dev babel-eslint@9.x eslint@5.x eslint-config-prettier@4.x eslint-config-react-app@4.x eslint-plugin-flowtype@2.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-prettier@3.x eslint-plugin-react@7.x eslint-plugin-react-hooks@1.x prettier@1.x
 // OR
-$ npm install --save-dev eslint prettier eslint-config-prettier eslint-plugin-import eslint-plugin-jsx-a11y eslint-plugin-flowtype eslint-plugin-prettier eslint-plugin-react babel-eslint
+$ npm install --save-dev babel-eslint@9.x eslint@5.x eslint-config-prettier@4.x eslint-config-react-app@4.x eslint-plugin-flowtype@2.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-prettier@3.x eslint-plugin-react@7.x eslint-plugin-react-hooks@1.x prettier@1.x
 ```
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -1,13 +1,6 @@
 module.exports = {
-    extends: [
-        'eslint:recommended',
-        'plugin:react/recommended',
-        'plugin:flowtype/recommended',
-        'prettier',
-        'prettier/flowtype',
-        'prettier/react',
-    ],
-    plugins: ['react', 'jsx-a11y', 'import', 'flowtype', 'prettier'],
+    extends: ['react-app', 'prettier', 'prettier/flowtype', 'prettier/react'],
+    plugins: ['prettier'],
     rules: {
         'prettier/prettier': [
             'error',
@@ -15,25 +8,11 @@ module.exports = {
                 singleQuote: true,
                 trailingComma: 'es5',
                 bracketSpacing: false,
-                jsxBracketSameLine: true,
                 parser: 'flow',
-                tabWidth: 4,
             },
         ],
         'block-scoped-var': 'warn',
         camelcase: 'warn',
         curly: ['error', 'all'],
-    },
-    parserOptions: {
-        ecmaVersion: 2017,
-        sourceType: 'module',
-        ecmaFeatures: {
-            experimentalObjectRestSpread: true,
-            jsx: true,
-        },
-    },
-    env: {
-        es6: true,
-        node: true,
     },
 };

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 module.exports = {
-    extends: ['react-app', 'prettier', 'prettier/flowtype', 'prettier/react'],
-    plugins: ['prettier'],
-    rules: {
-        'prettier/prettier': [
-            'error',
-            {
-                singleQuote: true,
-                trailingComma: 'es5',
-                bracketSpacing: false,
-                parser: 'flow',
-            },
-        ],
-        'block-scoped-var': 'warn',
-        camelcase: 'warn',
-        curly: ['error', 'all'],
-    },
+  extends: ['react-app', 'prettier', 'prettier/flowtype', 'prettier/react'],
+  plugins: ['prettier'],
+  rules: {
+    'prettier/prettier': [
+      'error',
+      {
+        singleQuote: true,
+        trailingComma: 'es5',
+        bracketSpacing: false,
+        parser: 'flow',
+      },
+    ],
+    'block-scoped-var': 'warn',
+    camelcase: 'warn',
+    curly: ['error', 'all'],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -17,14 +17,16 @@
   ],
   "repository": "ImprontaAdvance/eslint-config",
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
-    "eslint": ">=4.3.0",
-    "eslint-config-prettier": "^2.3.0",
-    "eslint-plugin-flowtype": "^2.35.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jsx-a11y": "^6.0.0",
-    "eslint-plugin-prettier": "^2.2.0",
-    "eslint-plugin-react": "^8.2.0",
-    "prettier": "^1.5.3"
+    "babel-eslint": "^9.0.0",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.2.0",
+    "eslint-config-react-app": "^4.0.0",
+    "eslint-plugin-flowtype": "^2.50.3",
+    "eslint-plugin-import": "^2.17.2",
+    "eslint-plugin-jsx-a11y": "^6.2.1",
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-react": "^7.13.0",
+    "eslint-plugin-react-hooks": "^1.5.0",
+    "prettier": "^1.17.0"
   }
 }


### PR DESCRIPTION
- Now it extends [eslint-create-react-app](https://www.npmjs.com/package/eslint-config-react-app)
- `tabWidth` reduced to default value (`2`)
- [`jsxBracketSameLine`](https://prettier.io/docs/en/options.html#jsx-brackets) is now `false`