### PR TITLE
change config extend due to update to eslint-config-prettier 8.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ const config = {
 
 if (moduleExists('eslint-config-prettier')) {
   config.extends.push('prettier');
-  config.extends.push('prettier/react');
   config.plugins.push('prettier');
   config.rules['prettier/prettier'] = [
     'error',

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   ],
   "repository": "ImprontaAdvance/eslint-config",
   "dependencies": {
-    "eslint-config-prettier": ">=6.0.0",
-    "eslint-plugin-prettier": ">=3.1.4",
-    "prettier": ">=2.1.2"
+    "eslint-config-prettier": "^8.0.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "prettier": "^2.1.0"
   },
   "peerDependencies": {
-    "eslint-config-react-app": ">=5.2.1"
+    "eslint-config-react-app": "^6.0.0"
   }
 }


### PR DESCRIPTION
 The prettier config now includes not just ESLint core rules, but also rules from all plugins.